### PR TITLE
Use Codecov action to publish report to codecov.io

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,10 @@ jobs:
 
     steps:
     - name: Checkout astronet
-      uses: actions/checkout@v2
+      uses: actions/checkout@master
+
+    - name: Codecov
+      uses: codecov/codecov-action@v1
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1


### PR DESCRIPTION
With this change, the code coverage report should be publish to Codecov.io	

    modified:   .github/workflows/pytest.yml